### PR TITLE
Add columns to L1B panel hover tool

### DIFF
--- a/mcstools/plotting/l1b_panel.py
+++ b/mcstools/plotting/l1b_panel.py
@@ -1,7 +1,7 @@
 import click
 import cmcrameri.cm as cm
-import hvplot.xarray  # noqa
 import holoviews as hv
+import hvplot.xarray  # noqa
 import panel as pn
 
 from mcstools.loader import L1BLoader
@@ -13,8 +13,10 @@ def plot(data):
     """
     Plot radiances as a function of UTC and detector.
     """
-    p = hv.QuadMesh(data, kdims=["dt", "Detector"], vdims=["Radiance", "Scene_lat", "Scene_lon", "LTST"],
-
+    p = hv.QuadMesh(
+        data,
+        kdims=["dt", "Detector"],
+        vdims=["Radiance", "Scene_lat", "Scene_lon", "LTST", "L_sub_s"],
     )
     return p
 
@@ -37,6 +39,7 @@ def all_plots(df_ave):
             width=1200,
             height=600,
             tools=["hover"],
+            line_alpha=0,
         )
         for d, c in zip(cdata, reader.channels)
     ]  # make all plots
@@ -88,7 +91,7 @@ def main(filestr) -> None:
         processer = L1BStandardInTrack()  # initialize processer
         df = processer.preprocess(df)  # reduce to in-track sequence-averaged data
         df_xr = processer.melt_to_xarray(
-            df, include_cols=["Radiance", "Scene_lat", "Scene_lon", "LTST"]
+            df, include_cols=["Radiance", "Scene_lat", "Scene_lon", "LTST", "L_sub_s"]
         )  # melt radiance columns to individual detectors
         tabs = all_plots(df_xr)  # generate all plots
         view = pn.Column(

--- a/mcstools/preprocess/l1b.py
+++ b/mcstools/preprocess/l1b.py
@@ -1,5 +1,3 @@
-import xarray as xr
-
 from mcstools.preprocess.data_pipeline import L1BDataPipeline
 from mcstools.util.log import logger
 
@@ -108,7 +106,7 @@ class L1BStandardInTrack:
         df = df.drop(columns="sequence_label")
         return df
 
-    def melt_to_xarray(self, df, include_cols = ["Radiance", "Scene_lat", "Scene_lon"]):
+    def melt_to_xarray(self, df, include_cols=["Radiance", "Scene_lat", "Scene_lon"]):
         """
         Convert Dataframe of L1b radiances to xarray with coordinates:
         ["dt", "Detector", "Channel"].
@@ -117,10 +115,9 @@ class L1BStandardInTrack:
             logger.warning("LTST not in data columns, try adding first.")
         pipe = L1BDataPipeline()
         df_melted = pipe.melt_channel_detector_radiance(df.reset_index())
-        ds = df_melted.set_index(["dt", "Detector", "Channel"])[include_cols].to_xarray()
-        # Add time-dimension only columns
-        #df = df.set_index("dt")
-        #ds = ds.assign(Scene_lat = df["Scene_lat"].to_xarray(), Scene_lon=df["Scene_lon"])
+        ds = df_melted.set_index(["dt", "Detector", "Channel"])[
+            include_cols
+        ].to_xarray()
         return ds
 
 


### PR DESCRIPTION
One reason to include the radiance viewer (L1B panel) is to allow the viewer to see time and location information about the measurement they're looking at. This includes the hover tool for each of the plots and adds the Ls, latitude, longitude, and local time fields to the hover tool.