### PR TITLE
Load from datetimes

### DIFF
--- a/mcstools/loader.py
+++ b/mcstools/loader.py
@@ -69,7 +69,7 @@ class L1BLoader:
             datetimes = list(set(datetimes))
         else:
             raise NotImplementedError(f"Loading from {type(datetimes)} not implemented.")
-        filestrs = [self.filename_builder.handler.convert_filestr_to_dt(d) for d in datetimes]
+        filestrs = [self.filename_builder.handler.convert_dt_to_filestr(d) for d in datetimes]
         files = [self.filename_builder.make_filename_from_filestr(f) for f in filestrs]
         return self.load(files)
 
@@ -198,7 +198,7 @@ class L2Loader:
             datetimes = list(set(datetimes))
         else:
             raise NotImplementedError(f"Loading from {type(datetimes)} not implemented.")
-        filestrs = [self.filename_builder.handler.convert_filestr_to_dt(d) for d in datetimes]
+        filestrs = [self.filename_builder.handler.convert_dt_to_filestr(d) for d in datetimes]
         files = [self.filename_builder.make_filename_from_filestr(f) for f in filestrs]
         return self.load(ddr, files, *kwargs)
 

--- a/mcstools/loader.py
+++ b/mcstools/loader.py
@@ -26,7 +26,7 @@ class L1BLoader:
         self.reader = L1BReader(pds=pds)
 
     def load(self, files, dask=False, add_cols: list = None):
-        if type(files).isinstance(list):
+        if isinstance(files, list):
             return self.reader.read(files, add_cols=add_cols)
         elif len(files) == 0:
             df = pd.DataFrame(columns=self.columns)
@@ -192,7 +192,7 @@ class L2Loader:
         return data
     
     def load_from_datetimes(self, ddr, datetimes, **kwargs):
-        if type(datetimes).isinstance(pd.Series):
+        if isinstance(datetimes, pd.Series):
             datetimes = datetimes.unique()
         elif type(datetimes).isinstance(list):
             datetimes = list(set(datetimes))

--- a/mcstools/loader.py
+++ b/mcstools/loader.py
@@ -132,7 +132,6 @@ class L2Loader:
                 self.filename_builder.make_filename_from_filestr(f) for f in filestrs
             ]
         # Only one file, just read
-        print(files)
         if not isinstance(files, (list, np.ndarray, pd.Series)):
             df = self.reader.read(files, ddr, add_cols)
             # Specific profiles, reduce data set

--- a/mcstools/loader.py
+++ b/mcstools/loader.py
@@ -2,6 +2,7 @@ import datetime as dt
 from typing import Union
 
 import dask.dataframe as dd
+import numpy as np
 import pandas as pd
 from dask import delayed
 from mars_time import MarsTime, marstime_to_datetime
@@ -26,7 +27,7 @@ class L1BLoader:
         self.reader = L1BReader(pds=pds)
 
     def load(self, files, dask=False, add_cols: list = None):
-        if isinstance(files, list):
+        if not isinstance(files, (list, np.ndarray, pd.Series)):
             return self.reader.read(files, add_cols=add_cols)
         elif len(files) == 0:
             df = pd.DataFrame(columns=self.columns)
@@ -61,16 +62,24 @@ class L1BLoader:
     def load_from_filestr(self, filestr, **kwargs):
         file = self.filename_builder.make_filename_from_filestr(filestr)
         return self.load(file, **kwargs)
-    
+
     def load_from_datetimes(self, datetimes, **kwargs):
-        if type(datetimes).isinstance(pd.Series):
-            datetimes = datetimes.unique()
-        elif type(datetimes).isinstance(list):
-            datetimes = list(set(datetimes))
+        """
+        Given a list of datetimes (does not need to be same precision as in MCS data),
+        load all files with those datetimes [does not reduce to only those datetimes].
+        """
+        if isinstance(datetimes, pd.Series):
+            pass
+        elif isinstance(datetimes, list):
+            datetimes = pd.Series(datetimes)
         else:
-            raise NotImplementedError(f"Loading from {type(datetimes)} not implemented.")
-        filestrs = [self.filename_builder.handler.convert_dt_to_filestr(d) for d in datetimes]
-        files = [self.filename_builder.make_filename_from_filestr(f) for f in filestrs]
+            raise NotImplementedError(
+                f"Loading from {type(datetimes)} not implemented."
+            )
+        filestrs = datetimes.apply(self.filename_builder.handler.convert_dt_to_filestr)
+        files = filestrs.apply(
+            self.filename_builder.make_filename_from_filestr
+        ).unique()
         return self.load(files)
 
     def load_files_around_date(self, date, n=1, **kwargs):
@@ -123,7 +132,8 @@ class L2Loader:
                 self.filename_builder.make_filename_from_filestr(f) for f in filestrs
             ]
         # Only one file, just read
-        if type(files).isinstance(list):
+        print(files)
+        if not isinstance(files, (list, np.ndarray, pd.Series)):
             df = self.reader.read(files, ddr, add_cols)
             # Specific profiles, reduce data set
             if profiles:
@@ -190,17 +200,25 @@ class L2Loader:
             data = data[(data["dt"] >= times[0]) & (data["dt"] < times[1])]
         data = data.drop(columns=remove_cols)
         return data
-    
+
     def load_from_datetimes(self, ddr, datetimes, **kwargs):
+        """
+        Given a list of datetimes (does not need to be same precision as in MCS data),
+        load all files with those datetimes [does not reduce to only those datetimes].
+        """
         if isinstance(datetimes, pd.Series):
-            datetimes = datetimes.unique()
-        elif type(datetimes).isinstance(list):
-            datetimes = list(set(datetimes))
+            pass
+        elif isinstance(datetimes, list):
+            datetimes = pd.Series(datetimes)
         else:
-            raise NotImplementedError(f"Loading from {type(datetimes)} not implemented.")
-        filestrs = [self.filename_builder.handler.convert_dt_to_filestr(d) for d in datetimes]
-        files = [self.filename_builder.make_filename_from_filestr(f) for f in filestrs]
-        return self.load(ddr, files, *kwargs)
+            raise NotImplementedError(
+                f"Loading from {type(datetimes)} not implemented."
+            )
+        filestrs = datetimes.apply(self.filename_builder.handler.convert_dt_to_filestr)
+        files = filestrs.apply(
+            self.filename_builder.make_filename_from_filestr
+        ).unique()
+        return self.load(ddr, files, **kwargs)
 
     def load_ls_range(
         self,


### PR DESCRIPTION
## Context
Wanted the ability to load data associated with specific datetimes. This requires converting the datetimes to the MCS data file format to generate a list of files. Currently, you have to load the FileFormatters to do that, and then feed the files into the loader. Here, I added a function to that, so the file names are generated under the hood.